### PR TITLE
fix(core): Limpieza de redundancias y eliminación de advertencias del…

### DIFF
--- a/tax-service/src/main/java/com/celotts/taxservice/infrastructure/adapter/input/rest/exception/GlobalExceptionHandler.java
+++ b/tax-service/src/main/java/com/celotts/taxservice/infrastructure/adapter/input/rest/exception/GlobalExceptionHandler.java
@@ -107,7 +107,8 @@ public class GlobalExceptionHandler {
             case 404 -> "ERR_NOT_FOUND";
             default -> "ERR_HTTP";
         };
-        String detail = ex.getBody() != null ? ex.getBody().getDetail() : msg("error.http.invalid");
+        // CORRECCIÓN APLICADA: Se eliminó la verificación de ex.getBody() != null
+        String detail = ex.getBody().getDetail();
         return ApiResponse.error(
                 status,
                 detail,

--- a/tax-service/src/main/resources/messages.properties
+++ b/tax-service/src/main/resources/messages.properties
@@ -56,8 +56,8 @@ error.forbidden=Forbidden
 
 # Logs - Debug
 log.tax=Tax
-log.with.id= with id: 
-log.with.name= with name: 
+log.with.id= with id:
+log.with.name= with name:
 log.tax.finding.byid=Finding tax by id: {0}
 log.tax.finding.byname=Finding tax by name: {0}
 log.tax.finding.all=Finding all taxes


### PR DESCRIPTION
… IDE

Se implementan correcciones menores para eliminar advertencias de redundancia de código (code smells) detectadas por IntelliJ, mejorando la limpieza de las clases de Core y REST.

Cambios principales:

1. GlobalExceptionHandler.java:

    * Se corrige el método handleErrorResponse eliminando la verificación redundante ex.getBody() != null, ya que el contrato de Spring garantiza que el cuerpo existe para ErrorResponseException.

2. TaxController.java (Corrección Pendiente):

    * Se refactorizan los métodos de utilidad resourceNotFoundException para eliminar la creación redundante de arrays (new Object[]{argument}) al llamar a métodos que esperan varargs.

3. AuditableEntity.java (Corrección Pendiente):

    * Se eliminan las asignaciones de valor predeterminadas redundantes (= LocalDateTime.now()) y los métodos @PrePersist/@PreUpdate manuales, confiando completamente en Spring Data JPA Auditing.