### PR TITLE
feat: implement i18n support for domain exceptions in purchase-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Thumbs.db
 # === Archivos de entorno (locales y secretos) ===
 infra/.env
 infra/.env.*
+infra/.build/

--- a/purchase-service/src/main/java/com/celotts/purchaseservice/application/usecase/PurchaseUseCaseImpl.java
+++ b/purchase-service/src/main/java/com/celotts/purchaseservice/application/usecase/PurchaseUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.celotts.purchaseservice.application.usecase;
 
+import com.celotts.purchaseservice.domain.exception.PurchaseAlreadyExistsException;
 import com.celotts.purchaseservice.domain.exception.PurchaseNotFoundException;
 import com.celotts.purchaseservice.domain.model.purchase.PurchaseModel;
 import com.celotts.purchaseservice.domain.port.input.PurchaseUseCase;
@@ -30,7 +31,11 @@ public class PurchaseUseCaseImpl implements PurchaseUseCase {
         }
 
         if(repositoryPort.existsByOrderNumber(purchase.getOrderNumber())) {
-            throw new RuntimeException("Order number already exists: " + purchase.getOrderNumber());
+            throw new PurchaseAlreadyExistsException(
+                    "purchase.already-exists",  // Llave
+                    "orderNumber",              // {0}
+                    purchase.getOrderNumber()   // {1}
+            );
         }
         return repositoryPort.save(purchase);
     }
@@ -53,16 +58,17 @@ public class PurchaseUseCaseImpl implements PurchaseUseCase {
         return repositoryPort.findById(id)
                 .map(existingPurchase -> {
                     purchase.setId(id);
+                    purchase.normalize();
                     return repositoryPort.save(purchase);
                 })
-                .orElseThrow(() -> new PurchaseNotFoundException("purchase.cannot-update-not-found: " + id));
+                .orElseThrow(() -> new PurchaseNotFoundException("purchase.cannot-update-not-found", id));
     }
 
     @Override
     @Transactional
     public void delete(UUID id) {
         if (!repositoryPort.existsById(id)) {
-            throw new PurchaseNotFoundException("purchase.cannot-delete-not-found: " + id);
+            throw new PurchaseNotFoundException("purchase.cannot-delete-not-found", id);
         }
         repositoryPort.deleteById(id);
     }

--- a/purchase-service/src/main/java/com/celotts/purchaseservice/domain/exception/PurchaseAlreadyExistsException.java
+++ b/purchase-service/src/main/java/com/celotts/purchaseservice/domain/exception/PurchaseAlreadyExistsException.java
@@ -1,11 +1,14 @@
 package com.celotts.purchaseservice.domain.exception;
 
 public class PurchaseAlreadyExistsException extends BaseDomainException {
-    public PurchaseAlreadyExistsException(String field, String value ) {
-        super("purchase.already-exists", field, value);
+
+    // Este constructor permite que el UseCase decida qué llave usar y qué argumentos pasar
+    public PurchaseAlreadyExistsException(String messageKey, Object... args) {
+        super(messageKey, args);
     }
 
-    public PurchaseAlreadyExistsException(String field, String value, Throwable cause) {
-        super("purchase.already-exist", cause, field, value);
+    // Opcional: Por si necesitas pasar una causa técnica (error de base de datos, etc.)
+    public PurchaseAlreadyExistsException(String messageKey, Throwable cause, Object... args) {
+        super(messageKey, cause, args);
     }
 }

--- a/purchase-service/src/main/java/com/celotts/purchaseservice/infrastructure/adapter/input/rest/exception/GlobalExceptionHandler.java
+++ b/purchase-service/src/main/java/com/celotts/purchaseservice/infrastructure/adapter/input/rest/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.celotts.purchaseservice.infrastructure.adapter.input.rest.exception;
 
+import com.celotts.purchaseservice.domain.exception.BaseDomainException;
 import com.celotts.purchaseservice.domain.exception.PurchaseNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -8,18 +11,40 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.celotts.purchaseservice.infrastructure.adapter.input.rest")
+@RequiredArgsConstructor // Para inyectar MessageSource
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(PurchaseNotFoundException.class)
-    public ResponseEntity<Map<String, Object>> handleNotFound(PurchaseNotFoundException ex) {
+    private final MessageSource messageSource;
+
+    // CAPTURA TODAS LAS EXCEPCIONES DE DOMINIO (NotFound, AlreadyExists, etc.)
+    @ExceptionHandler(BaseDomainException.class)
+    public ResponseEntity<Map<String, Object>> handleDomainException(BaseDomainException ex, Locale locale) {
         Map<String, Object> response = new HashMap<>();
         response.put("timestamp", LocalDateTime.now());
-        response.put("message", ex.getMessage());
-        response.put("status", HttpStatus.NOT_FOUND.value());
-        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+
+        String message;
+        try {
+            if (ex.isI18n()) {
+                // Traduce usando la llave (ej: purchase.error.already-exists)
+                message = messageSource.getMessage(ex.getMessageKey(), ex.getMessageArgs(), locale);
+            } else {
+                message = ex.getMessage();
+            }
+        } catch (Exception e) {
+            message = "Error code: " + ex.getMessageKey(); // Fallback si no existe la llave
+        }
+
+        response.put("message", message);
+
+        // Determinamos el status dinámicamente
+        HttpStatus status = (ex instanceof PurchaseNotFoundException) ? HttpStatus.NOT_FOUND : HttpStatus.CONFLICT;
+        response.put("status", status.value());
+
+        return new ResponseEntity<>(response, status);
     }
 
     @ExceptionHandler(org.springframework.web.bind.MethodArgumentNotValidException.class)

--- a/purchase-service/src/main/resources/messages.properties
+++ b/purchase-service/src/main/resources/messages.properties
@@ -49,6 +49,10 @@ purchase.delete.deletedBy.size=DeletedBy max length is 100 characters
 purchase.delete.deletedBy.pattern=DeletedBy contains invalid characters 
 purchase.delete.reason.size=Reason must not exceed 255 characters 
 purchase.enabled.invalid=Enabled flag must be true or false
+purchase.already-exists=A purchase with {0} = {1} already exists.
+purchase.error.already-exists=A purchase already exists with order number: {0}
+purchase.cannot-update-not-found=Could not update: the purchase with ID {0} does not exist.
+purchase.cannot-delete-not-found=Could not delete: the purchase with ID {0} does not exist.
 
 # ---- Purchase Error Messages
 purchase.not-found-with-id=Purchase not found with ID: {0}

--- a/purchase-service/src/main/resources/messages_es.properties
+++ b/purchase-service/src/main/resources/messages_es.properties
@@ -23,7 +23,6 @@ validation.code.pattern=El código debe tener entre 3 y 40 caracteres y solo pued
 validation.field-error=Campo inválido: {0}
 validation.missing-param=El parámetro '{0}' es obligatorio
 validation.trimmed-not-blank=No debe estar vacío ni contener solo espacios
-l proveedor no existe
 validation.purchase.id.not-found=El ID de la compra no existe
 
 # ---- Pageable
@@ -49,7 +48,11 @@ purchase.delete.deletedBy.size=La longitud máxima de 'Eliminado por' es de 100 c
 purchase.delete.deletedBy.pattern='Eliminado por' contiene caracteres no válidos
 purchase.delete.reason.size=El motivo no debe exceder los 255 caracteres
 purchase.enabled.invalid=El indicador de habilitado debe ser verdadero o falso
-
+purchase.already-exists=Ya existe una compra con {0} = {1}
+purchase.cannot-update-not-found=No se pudo actualizar: la compra con ID {0} no existe.
+purchase.cannot-delete-not-found=No se pudo eliminar: la compra con ID {0} no existe.
+purchase.error.already-exists=Ya existe una compra con el número de orden: {0}
+purchase.not-found=No se encontró la compra con el identificador proporcionado.
 # ---- Purchase Error Messages
 purchase.notFoundWithId=Compra no encontrada con ID: {0} 
 Cannot.update.purchase.notFound.with.ID=No se puede actualizar, compra no encontrada con ID: {0}


### PR DESCRIPTION
- Refactored PurchaseAlreadyExistsException to use message keys
- Updated GlobalExceptionHandler to resolve messages via MessageSource
- Added support for dynamic Locale based on Accept-Language header
- Added localized messages for Spanish and English